### PR TITLE
fix: Replaced '!==' with '!=' to correct a syntax error in Groovy

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -68,7 +68,7 @@ def loadSelligentSettings(variant) {
     def defaultSelligentFileName = "selligent.json"
     File defaultFile = new File("$project.rootDir/../$defaultSelligentFileName")
 
-    if (currentFlavor !== "") {
+    if (currentFlavor != "") {
         defaultFile = new File("$project.rootDir/../$currentFlavor/$defaultSelligentFileName")
     }
 


### PR DESCRIPTION
Replaced '!==' with '!=' to correct a syntax error in Groovy